### PR TITLE
Wire Relume Library MCP (July 2026)

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "relume-library": {
+      "url": "https://relume-library-mcp.relume.io/mcp"
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+.worktrees
 dist
 dist-ssr
 *.local

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This mix keeps the rebuild house — the dusk triptych, long-form case studies w
 - React Router 7 for routed pages
 - Material 3 Expressive token and component layer
 - Source Serif 4 (brand), IBM Plex Sans (plain), IBM Plex Mono (figures and labels)
+- Optional Relume Library MCP ([July 2026](https://www.relume.ai/whats-new/july-2026-release)): Cursor config in `.cursor/mcp.json`. Sign in with a paid Relume account. It vendors Relume React + Tailwind primitives; it does not replace this site’s type or M3 tokens.
 
 ## Running It
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist', 'src/legacy/**']),
+  globalIgnores(['dist', 'src/legacy/**', '.worktrees/**']),
   {
     files: ['**/*.{js,jsx}'],
     extends: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The [July 2026 Relume release](https://www.relume.ai/whats-new/july-2026-release) is the **Relume Library MCP**: 1000+ real components searchable from Cursor, not a typeface change.

This PR:

- Adds `.cursor/mcp.json` pointing at `https://relume-library-mcp.relume.io/mcp` ([product page](https://www.relume.ai/relume-library-mcp)).
- Notes it in the README stack next to the existing fonts. Site type stays Source Serif 4 / IBM Plex. Relume’s Tailwind preset is **not** applied.
- Makes README **Running It** actually pass here: `eslint .` was linting `.worktrees/*/dist` flavor bundles. Those paths are now ignored.

**Auth:** the MCP endpoint returns 401 without a Relume OAuth token. Relume documents this as **paid-plan** + sign-in. After merge, complete MCP auth in Cursor Settings → MCP.

**Verified:** `npm run tokens && npm run lint && npm run facts && npm run smoke && npm run build` — all pass. Preview serving at `http://127.0.0.1:4180/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b25081f4-57e1-4ce7-b925-cb244a24a347?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b25081f4-57e1-4ce7-b925-cb244a24a347&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Wire up Relume Library MCP as an optional design/library integration accessible via Cursor configuration, without changing the site’s existing Material 3 and typography setup.

New Features:
- Add `.cursor/mcp.json` configuration to enable use of the Relume Library MCP from Cursor for pulling Relume React/Tailwind blocks.

Documentation:
- Update README stack description to mention the optional Relume Library MCP integration, its configuration file, and usage/auth requirements.