### PR TITLE
Teach the post-training Qwen paint grammar as loadable skills

### DIFF
--- a/.opencode/skills/browser-qa/SKILL.md
+++ b/.opencode/skills/browser-qa/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: browser-qa
+description: How to visually verify this site with a real browser in this sandbox — dev/preview servers, the browser-use audit script pattern (with its API quirks), what to probe in light and dark mode, and tunneling for the owner. Load before claiming any visual change "works".
+---
+
+# Browser QA in this sandbox
+
+## Servers
+
+- Dev (HMR): `npx vite --host 0.0.0.0 --port 5173 --strictPort` →
+  `http://127.0.0.1:5173/`. Owner reaches it through the Cursor port
+  forward; the `172.x` address is NOT reachable from their laptop.
+- Production preview: `npx vite preview --config /tmp/opencode/vite.preview.config.mjs --host 127.0.0.1 --port 4173`
+  (the overlay sets `preview.allowedHosts: true` for tunnel hostnames
+  without touching the repo's `vite.config.js`).
+- Public tunnel: `/tmp/opencode/cloudflared tunnel --url http://127.0.0.1:4173 --no-autoupdate`
+  (binary is downloaded; re-fetch from the cloudflared releases if
+  missing). Parse the `https://*.trycloudflare.com` URL from the log.
+  URLs are ephemeral.
+
+## The browser-use pattern (installed: pip `browser-use` + playwright chromium)
+
+`src/components` render client-side, so `curl` cannot verify markup. Use
+`browser_use.BrowserSession(headless=True)`; its `get_current_page()`
+returns a CDP wrapper with a DIFFERENT API from playwright:
+
+- `page.goto(url)` — no `wait_until` kwarg. Vite's HMR websocket means
+  `networkidle` would hang anyway; follow gotos with
+  `await page.evaluate("() => new Promise(r => setTimeout(r, 900))")`.
+- `page.evaluate(js)` — js MUST be an arrow function string
+  (`"() => {...}"`); it returns a JSON string, `json.loads` it.
+- `page.screenshot(format='png')` — returns bytes (no `path` kwarg);
+  write the file yourself.
+- No console-event listeners on this wrapper. For console capture, use
+  raw `playwright.sync_api` instead (also installed) — it is the right
+  tool when you need response interception (e.g. pulling p5 editor
+  sketch JSON) or console logs.
+
+## What to probe per sweep
+
+Run routes in light, then set
+`localStorage.setItem('site-mode','dark')` and repeat the key ones:
+
+1. `data-theme` on the themed root resolves with mode
+   (`study-light` / `study-dark` / `ryukijano-…`).
+2. Atmosphere: `.atmo__grain` computed opacity ≈ 0.055 and
+   `mix-blend-mode: soft-light`; `.atmo__rings` present on full pages
+   (/, /work, /trust, /blog index, personas, /nope) and ABSENT on quiet
+   pages (notes, case studies) and the home folio.
+3. Nav mode toggle flips `html[data-mode]` and persists across reload.
+4. h1/title sanity per route; 404 routes show the archivist copy.
+5. Narrow viewport (≤599px): folio lanes stack as cards under the plate.
+
+Screenshots go to `/tmp/opencode/shots/`. Read them with the Read tool —
+probes alone have missed visual regressions before.
+
+## Known environment traps
+
+- Backgrounding servers: use
+  `(setsid nohup … >/tmp/opencode/x.log 2>&1 </dev/null &)`; a bare `&`
+  wedges the tool shell. Never `pkill -f "vite"` — the pattern matches
+  the invoking shell itself; use `pkill -f "[v]ite"`.
+- `npm run preview` without the allowedHosts overlay 403s tunnel
+  hostnames (Vite host guard, not the tunnel).

--- a/.opencode/skills/content-authoring/SKILL.md
+++ b/.opencode/skills/content-authoring/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: content-authoring
+description: How to write a new field note or case study for this site — file shape, required disclosure language, asset conventions, fact registration, and the voice. Load when adding or heavily editing any file in src/content/blog/ or src/content/caseStudies/.
+---
+
+# Authoring notes and case studies
+
+## Field notes (`src/content/blog/*.js`)
+
+Required shape (checked by `npm run notes`):
+
+- `slug`, `title`, `area`, `desc`, `lead` — all present.
+- Sections MUST include kickers `THE JOB`, `MECHANICS`, `THE DOMAIN`.
+- `instance.quote` required. `next: { slug, label }` must point at an
+  existing note.
+- If `concept` exists, its caption MUST contain one of
+  `schematic|illustrative|framing`.
+- Assets referenced (`concept.src/poster`, `instance.gif.src`) must exist
+  under `public/`.
+
+Voice: first person is allowed but must stay evidential. Openers must not
+be project-diary (`/^i built /i` and friends are banned). The standing
+disclosures are: figures are "a schematic of X, not a measured Y";
+training claims are denied where true ("I have not trained LLaDA" is a
+counted string on `/blog/diffusion-objectives`).
+
+Register target: confident, not cocky. See `.opencode/skills/site-gates/`
+for the voice rules and `humanizer/SITE-OVERRIDE.md` for precedence.
+
+## Case studies (`src/content/caseStudies/*.js`)
+
+- Shape mirrors existing files: `slug, status, source, year, lane, desc,
+  breadcrumb, kicker, title, lead, meta[], hero{src,poster,alt,caption},
+  sections{...}, next[]` — copy a sibling file's skeleton.
+- Every generated/illustrative figure caption MUST disclose:
+  "a schematic of …, not a measured …" or "illustrative, not model
+  output" (presence-checked per route in `fact-check.jsx` MUST_WORDS).
+- Numbers are facts: before adding or changing any figure, register it in
+  `fact-check.jsx` with its exact expected count. Figures without a
+  source do not go in.
+- `next[]` link targets use `href('Case Study - Name.dc.html')` from
+  `../links.js`.
+
+## Assets
+
+- GIFs live in `public/assets/gifs/`, posters (reduced-motion stills) in
+  `public/assets/images/` as `<name>-poster.png`.
+- `MediaFigure` swaps GIF → poster automatically under
+  `prefers-reduced-motion`. Always supply a poster for new GIFs.
+- Note GIFs are matplotlib outputs from `tools/make-note-gifs.py`; no
+  AI video generation (Veo/Omni/Higgsfield are unauthenticated here).
+
+## Registering new facts
+
+1. Add the claim to the content file with its exact final wording.
+2. Add a `[needle, count]` pair to the route's list in `fact-check.jsx`.
+3. `npm run facts` — it must pass with the new pair. If it fails, the
+   prose is wrong, not the check.
+
+## Tone calibration examples (from the 2026-08-24 pass)
+
+- Good: "sqd found −2.15 eV at the fcc site against a dft reference of
+  −2.20 eV, under 5% error, at a depth below 100 gates."
+- Preachy (avoid): "Do not read them as clinical or industrial
+  deployments." → declarative: "…weekend-scale builds, prototypes rather
+  than clinical or industrial deployments."
+- Cocky (avoid): "it's also the best thing on the site."
+- One hedge per passage; vary the "X, not Y" shape; em-dash ceiling is
+  4 per file.

--- a/.opencode/skills/creative-rl-design/SKILL.md
+++ b/.opencode/skills/creative-rl-design/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: creative-rl-design
+description: Design aesthetic or creative RL the way the paint-with-code Qwen run actually worked after the first reward collapsed — pairwise VLM vs a hand-rated pool, one real image metric, tiny compile/length gates, GEPA on a short allowlist not a 400-line spec. Use when choosing rewards for images/code aesthetics, GRPO for generative art, reference pools, or prompt optimisation for a constrained API.
+---
+
+# Creative RL as a reward-design problem
+
+The paint-with-code run (Qwen 3.5 35B, GRPO, p5.brush in a Puppeteer sandbox) did not stall because the model was too small. It stalled because the **reward was a committee of correlated judges plus a length ramp**. Load this skill when you are about to write a reward, a preference pool, or a system prompt for a tool-using generator.
+
+How the trained policy *draws*: skill `paint-with-code`. Numbers and loop: [references/training-loop.md](references/training-loop.md).
+
+Source: [Training AI to Paint with Code](https://surya.website/rling-qwen-to-paint-with-code) — Surya Narreddi, Cameron Franz, Alex Wang. Dated March 2026; page last seen updated 2026-08-23. Not Gyanateet's run.
+
+## The loop that shipped
+
+```
+prompt  →  policy writes complete p5.brush JS
+        →  Puppeteer sandbox PNG (compile or die)
+        →  pairwise VLM vs two refs from a hand-rated pool
+        →  GRPO
+```
+
+The judge question is relative, not a score: *which of these is the better hibiscus watercolour?* Reward is the **fraction of comparisons won**.
+
+Sandbox is the environment. The VLM is not the policy. Do not train the painter to emit scores.
+
+## Reward (after collapse)
+
+Four terms. Same base model, same prompts. Reached the old ~0.65 plateau three times faster, then climbed. Completions **13,500 → under 2,000 tokens**.
+
+| Term | Weight | Job |
+| --- | --- | --- |
+| Compile + uses-brush | 0.05 | **binary** gate: ran, called p5.brush not only native p5 |
+| Length | 0.05 | **binary** check, not a ramp. The old ~⅓-of-reward length ramp saturated by step 30 and produced zero gradient |
+| HPSv3 | 0.30 | the one automatic metric that still had variance |
+| Pairwise vs pool | 0.60 | win rate against two draws from the hand-rated refs |
+
+They did **not** get to the next step: train a small reward model on the ratings (proper RLHF) so scoring would not need the pool at every step. Do not write as if they did.
+
+## What not to do (the 9-signal failure)
+
+First rubric: compilation gate, uses-brush check, length ramp targeting ~3,000 tokens, HPSv3 at **0.10**, prompt-adherence council (GPT-5.4 + Gemini), plus four quality judges (recognisability, aesthetics, technique, depth).
+
+Plateau ~0.65. Every rollout the same flat five-petal clip-art. Reward still rose.
+
+Diagnosis:
+
+- Four quality judges + adherence correlated **0.85–0.95** — one signal, five coats of paint.
+- Length ≈ one third of total reward, dead after step 30.
+- HPSv3 (real variance) under-weighted at 0.10.
+- Absolute 0–10 scores came back **compressed near zero**.
+
+Rules:
+
+1. **Do not average five aesthetic judges.** If they correlate, keep one pairwise comparison.
+2. **Do not let length dominate.** Make it a small binary gate. Short code that paints is what the new run learned.
+3. **Put weight where there is variance.** Here: HPSv3 + pool pairwise, not "rate 1–10 adherence".
+4. **Pairwise vs a pool beats absolute scores.** "Better than these two love-tier sheets?" opened dynamic range. "Score 0–10" did not.
+
+## The pool is the taste
+
+| Number | What |
+| --- | --- |
+| 1,664 | generations sorted by hand into love / okay / nope |
+| 117 | love-tier (seeded the comparison pool) |
+| 266 | okay |
+| 198 | supplements from a later run (widen thin colour slices) |
+| 581 | refs actually used (117 + 266 + 198) |
+
+**Every pool image is model output.** They could not source enough human p5.brush paintings. The prior you will get is the prior you rate. August samples are still hibiscus because the pool was.
+
+Pool generators: AutoResearch (Opus 4.6, GPT-5.4, Gemini 3.1 Pro) iterating against reference photographs under a VLM judge, plus a larger Gemini 3.1 Pro batch. Both used a system prompt evolved with **GEPA**.
+
+## GEPA on the tool spec
+
+400-line API dump → confident code that **invented methods** → empty canvases.
+
+200 iterations against a taste-anchored **7-shot** judge. Converged on a prompt with a **strict allowlist of eight brush methods, no API documentation, no examples**. First 3/3 visible hibiscus blobs was the version written **after throwing the spec out**.
+
+When prompting a constrained library:
+
+- Name the allowed calls. Stop.
+- Do not include the README.
+- Few-shot **taste** for the judge is separate from few-shot **API** for the policy. Do not put clip-art full sketches in the tool spec if that is the attractor you are trying to escape.
+
+Post-training August sketches use a slightly larger closed list (see `paint-with-code` allowlist). Still not the README.
+
+## Honesty when writing this up
+
+- They do not claim this is a better way to make images. It is slower. The claim is: **RL on aesthetics is a design problem for the reward** (too rigid → copy the pool; too loose → learn nothing).
+- Project ongoing; one further training run was planned to fix issues found along the way.
+- A full technical report was promised for June 2026. Do not invent that it shipped.
+- Cite Surya Narreddi, Cameron Franz, Alex Wang. Do not attribute the run to Gyanateet. Not a `/work` entry. Not a replacement for the Kanagawa plate.
+
+## Done when
+
+- Reward has at most one correlated aesthetic head, expressed as pairwise vs a rated pool.
+- Compile / tool-use is a small **binary** gate, not the objective.
+- Length cannot outvote image quality (binary, tiny weight).
+- Tool prompt is an allowlist, not an API manual.
+- Pool labels match the taste you actually want after training.

--- a/.opencode/skills/creative-rl-design/references/training-loop.md
+++ b/.opencode/skills/creative-rl-design/references/training-loop.md
@@ -1,0 +1,58 @@
+# Training loop (paint-with-code Qwen)
+
+Narrative: https://surya.website/rling-qwen-to-paint-with-code — dated March 2026, page seen updated 2026-08-23. Team: Surya Narreddi (design, development, RL research), Cameron Franz (training infrastructure), Alex Wang. Conversations with Evan Casey on reward as a creative artefact.
+
+Treat the essay as the **reward story**. Treat the 2026-08-23 editor sketches as **post-training behaviour** (skill `paint-with-code`). A cached diagram names the policy **Qwen 3.5 35B**; the essay itself says "a language model".
+
+## Environment
+
+- Example prompt: *draw a peach hibiscus in watercolour*.
+- Policy emits **complete JavaScript** for p5 + p5.brush.
+- Puppeteer sandbox renders a PNG. No compile → no image → gate fails.
+- Judge: separate VLM, pairwise against **two** images from the hand-rated pool. Prompt: *which of these is the better hibiscus watercolour?* Reward = win fraction.
+- Optimiser: **GRPO**.
+
+## Old reward (plateau ~0.65)
+
+Nine signals: compile, uses-brush, length ramp (~3,000 token target, ~⅓ of total, dead by step 30), HPSv3 at 0.10, prompt adherence (GPT-5.4 + Gemini council), four quality judges. Quality + adherence correlated 0.85–0.95. Absolute 0–10 scores compressed near zero. Collapse: one 5-petal clip-art, padded code, rising scalar.
+
+## New reward (climbed)
+
+```
+0.05  binary compile && uses p5.brush
+0.05  binary length check
+0.30  HPSv3
+0.60  pairwise vs two pool refs
+```
+
+Same model, same data. Hit the old plateau 3× faster, kept climbing, code 13.5k → <2k tokens.
+
+Not done: train a small RM on love/okay/nope (RLHF) so the pool is not queried every step.
+
+## Pool construction
+
+| Number | What |
+| --- | --- |
+| 1,664 | generations sorted by hand |
+| 117 | love-tier |
+| 266 | okay |
+| 198 | supplements (thin colour slices) |
+| 581 | refs used |
+| 200 | GEPA iterations on the generator system prompt |
+| 7 | shots on the taste judge |
+
+All refs are **model-rendered**. Human paintings in this stack were too scarce.
+
+Pipelines: AutoResearch (Opus 4.6, GPT-5.4, Gemini 3.1 Pro) vs reference photographs + VLM feedback; larger Gemini 3.1 Pro batch.
+
+## GEPA lesson (prompt, not weights)
+
+Dumping p5.brush docs taught the pre-RL model to call ghosts. Winning prompt: closed method list, no commentary. Post-training August code uses ~19 `brush.*` names (see paint-with-code allowlist) — still not the 59k README.
+
+## Transfer warning
+
+Pairwise-vs-pool improved *quality relative to the pool*. It did not invent a new subject class. Skills that "paint like Qwen after training" will hibiscus unless the human prompt fights that prior.
+
+## Site / CV rule
+
+Literature for notes on GRPO / circuit search / agent skills. **Not** a `/work` entry. **Not** Gyanateet's training result.

--- a/.opencode/skills/paint-with-code/SKILL.md
+++ b/.opencode/skills/paint-with-code/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: paint-with-code
+description: Write a complete p5.brush sketch in the post-training Qwen 3.5 35B paint-with-code grammar — WEBGL 600 canvas, observed allowlist, unrolled motif calls, herbarium / ornamental tile / tropical glaze recipes. Use when emitting p5.js + p5.brush, painting with code, generative watercolour, or botanical plates. Not for claiming Gyanateet trained this model.
+---
+
+# Paint with code (post-training Qwen grammar)
+
+Load **before** writing any p5.brush sketch. Emit a complete `index.html` + `sketch.js`. Do not dump the p5.brush README. Do not invent methods.
+
+This grammar is reverse-engineered from Surya Narreddi, Cameron Franz, and Alex Wang: the March 2026 write-up plus three p5 editor sketches created **2026-08-23**. You are copying how the **policy draws after training**, not Gyanateet's CV. Do not put hibiscus on `/work`. Do not replace the Kanagawa plate.
+
+Signatures: [references/allowlist.md](references/allowlist.md). Recipes: [references/sketch-fingerprints.md](references/sketch-fingerprints.md). Grammar moved onto a new subject: [references/transfer-example.md](references/transfer-example.md). Reward-side method: skill `creative-rl-design`.
+
+## HTML pins (MUST)
+
+Match the August samples (cdnjs p5, jsDelivr brush), not a guessed dist path:
+
+```html
+<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/2.2.0/p5.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/p5.brush@2.1.0-beta"></script>
+```
+
+p5.brush needs **WEBGL**. A 2D canvas will not paint.
+
+## Scaffold (MUST)
+
+All three post-training sketches share this shape. `noLoop()` may live in `setup()` (2/3) or at the end of `draw()` (herbarium). Prefer `setup()`.
+
+```js
+async function setup() {
+  createCanvas(600, 600, WEBGL);
+  angleMode(DEGREES);
+  brush.scaleBrushes(3); // required for built-in brushes at 600px
+  noLoop();
+}
+
+function draw() {
+  translate(-width / 2, -height / 2); // WEBGL origin is centre
+  background("#f4e8c1");              // paper; then paint with brush.*
+  // ...
+}
+```
+
+`background()` is used. Ground can also be stacked `brush.rect` glazes (tropical). Do not skip `scaleBrushes(3)`.
+
+p5 state that the policy used freely: `push`, `pop`, `translate`, `rotate`, `random`, `color`, `lerpColor`, `width`, `height`.
+
+## Allowlist (MUST)
+
+Only these `brush.*` calls. August code is **larger than GEPA's eight-method prompt**; it is still a closed set. Full signatures in the allowlist file.
+
+| Kind | Calls |
+| --- | --- |
+| Setup | `scaleBrushes`, `set`, `field`, `noField` |
+| Stroke | `line`, `flowLine` |
+| Fill | `fill`, `noFill`, `noStroke`, `fillBleed`, `fillTexture` |
+| Hatch | `hatchStyle`, `hatch`, `noHatch` |
+| Geometry | `circle`, `rect`, `beginShape`, `vertex`, `endShape` |
+
+Brushes observed: `"2H"`, `"HB"`, `"2B"`, `"pen"`. Fields observed: `"hand"`, `"curved"`. Do not pick `"watercolor"`, `"rotring"`, `"waves"`, `"zigzag"` unless the human prompt names them — the trained samples did not.
+
+**Forbidden:** `brush.pick`, `load`, `polygon`, `spline`, `arc`, `blob`, `petal`, `wash`, `mass`, `addField`, `wiggle`, extra CDNs. Those names are how pre-RL samples compiled to empty canvases.
+
+## How the trained policy writes (MUST)
+
+1. **Unroll compositional units.** Nine tiles are nine `motifAt(...)` lines. Five petals are `petal(0)` … `petal(4)`. Fourteen glazes are fourteen `glazeFlower(...)` calls. Comments say `unrolled`. A `for` over petals or cells is the clip-art attractor they RL'd away from.
+2. **Helpers are fine.** `drawHibiscus`, `drawPetal`, `bgGlaze` exist. The scar is unrolled *calls*, not a ban on functions.
+3. **`for` is only cheap dust.** Grid lines, border dots, pollen specks. Hill feast comments this: `tiny + cheap — safe as a loop`. Herbarium also uses `for` for the **ruled grid** (not for flowers).
+4. **Fill opacity is 0–255.** `brush.fill("#c68e8c", 45)` is commented `~18%`. Never treat the second arg as 0–100.
+5. **`brush.circle(x, y, radius, irregularity)`.** Third arg is **radius**, not diameter. Fourth is 0–1 wobble (or omit).
+6. **Layer like a painter.** Paper → stains/glazes → large colour masses (`noStroke`, fill, bleed, texture, hatch) → structure lines (`set` a pencil) → tiny dark accents. `noFill()` + `noHatch()` before leader lines.
+7. **Field is a material.** `"hand"` on torn parchment edges. `"curved"` on tropical wet masses. `noField()` on grids, scale bars, and corner ticks.
+8. **Ragged, not polar clip-art.** Herbarium petals are jittered polylines; buds stay half-open; something has fallen. Five-petal × 72° is allowed on **ornamental tiles** (Hill feast) and tropical hibiscus, not on a naturalistic plate unless the prompt is a rosette.
+
+## Pick a recipe, then change the subject
+
+| Recipe | Job | Sample |
+| --- | --- | --- |
+| Herbarium plate | tea stain, grid, leader lines, scale bar, half-open + fallen forms | [Example code 1](https://editor.p5js.org/kickingkeys/sketches/u3UerBiFY) |
+| Ornamental tile | 3×3 repeat, gold/teal/rose/crimson, unrolled cells, corner ticks | [Hill feast](https://editor.p5js.org/kickingkeys/sketches/2EkeaajQA) |
+| Tropical glaze | `#051208` ground, unrolled blooms/glows/flowers, `field("curved")`, `flowLine` stamen | [Example 2](https://editor.p5js.org/kickingkeys/sketches/pxoWEbk9C) |
+
+Steal the **job**, not the hibiscus. The pool was hibiscus-heavy; post-training samples still are. Fight that prior unless the prompt is a hibiscus.
+
+## Length
+
+Target **under ~2k tokens** of JS (samples are 3.6–4.4k characters). The trained policy compressed 13.5k → <2k tokens. If the file is a novel, you are in the old length-reward regime — cut.
+
+## Done when
+
+- Pins, WEBGL, `scaleBrushes(3)`, and the `draw()` translate match the scaffold.
+- Every `brush.*` call is on the allowlist, with the signatures in the allowlist file.
+- Motifs are unrolled calls; only dust/grid loops.
+- One recipe's layering is visible, not a centred 5-petal icon on white.
+- Subject matches the prompt.

--- a/.opencode/skills/paint-with-code/references/allowlist.md
+++ b/.opencode/skills/paint-with-code/references/allowlist.md
@@ -1,0 +1,70 @@
+# Observed p5.brush allowlist
+
+Closed set from three post-training sketches created 2026-08-23 (`kickingkeys` on the p5 editor). Broader than GEPA's original "eight methods, no docs" **prompt** — that prompt is how they got compilation; this list is how the **August policy actually draws**. Do not paste the upstream README.
+
+Third argument to `circle` is **radius**. Fill opacity is **0–255** (herbarium comments: `45` ≈ 18%).
+
+## Signatures as used
+
+```js
+brush.scaleBrushes(3);                      // setup, 600px canvas
+
+brush.set("2H", "#7a7465", 0.15);           // brushName, hex, weight
+brush.field("hand");                        // "hand" | "curved"
+brush.noField();
+
+brush.line(x1, y1, x2, y2);
+brush.flowLine(x, y, length, angleDeg);     // tropical stamens only
+brush.circle(x, y, radius);                 // or (x, y, radius, irregularity 0–1)
+brush.rect(x, y, w, h);                     // or (x, y, w, h, "center")
+
+brush.fill("#c68e8c", 45);                  // hex | p5.Color, opacity 0–255
+brush.noFill();
+brush.noStroke();
+brush.fillBleed(0.4, "out");                // strength 0–1; optional "out"|"in"
+brush.fillBleed(0.05);                      // strength only is valid
+brush.fillTexture(0.85, 0.9);               // texture 0–1, border 0–1
+
+brush.hatchStyle("HB", "#2a2a2a", 0.4);     // brushName, color, weight — NOT "line"
+brush.hatch(6, 45, { rand: 0.1 });          // spacing, angleDeg, { rand }
+brush.noHatch();
+
+brush.beginShape(0.4);                      // curvature 0–1
+brush.vertex(x, y);
+brush.endShape(true);                       // close; CLOSE also appears and is truthy
+```
+
+## Brushes observed
+
+| Name | Used for |
+| --- | --- |
+| `2H` | pale grid, leader lines, light structure |
+| `HB` | stems, veins, hatch style, herbarium outlines |
+| `2B` | gold ornamental border |
+| `pen` | fine ink veins, stamens, pollen |
+
+## Fields observed
+
+| Name | Used for |
+| --- | --- |
+| `hand` | torn parchment edge (then `noField()`) |
+| `curved` | tropical wet petal masses (then `noField()`) |
+
+Do not activate `waves`, `zigzag`, `seabed`, `spiral`, `columns` unless the human prompt names a field. The trained samples did not.
+
+## Fill pairing (the usual stack)
+
+```
+noStroke
+fill(hex, 0–255)
+fillBleed(0–1, "out"|"in")     // optional
+fillTexture(0–1, 0–1)          // optional
+hatchStyle + hatch             // optional; herbarium/tile
+circle | rect | beginShape…endShape
+noHatch / noFill               // before hairline work
+set(pencil) + line
+```
+
+## Do not call
+
+Anything not listed. Especially botanical-sounding ghosts (`petal`, `blob`, `watercolour`) and API-dump leftovers (`pick`, `load`, `polygon`, `spline`, `arc`, `wash`, `mass`, `addField`, `wiggle`). Those are how pre-RL samples compiled to empty canvases.

--- a/.opencode/skills/paint-with-code/references/sketch-fingerprints.md
+++ b/.opencode/skills/paint-with-code/references/sketch-fingerprints.md
@@ -1,0 +1,62 @@
+# Post-training sketch fingerprints
+
+Three public sketches, all created 2026-08-23, user `kickingkeys`. Same pins (p5 2.2.0 + p5.brush 2.1.0-beta), same WEBGL 600 scaffold, different **jobs**. Copy the job. Do not copy the hibiscus unless the prompt is a hibiscus.
+
+Editor JSON (needs a browser User-Agent): `https://editor.p5js.org/editor/kickingkeys/projects/<id>`
+
+## Shared scars
+
+- `async function setup()` + `function draw()` + `translate(-width/2, -height/2)` first in `draw()`.
+- Comments: `unrolled` on motif/petal/glaze **calls**; `tiny + cheap — safe as a loop` on stipple/pollen/border dots.
+- Helpers exist (`drawPetal`, `glazeFlower`, `motifAt`). Compositional units are invoked by repeating the call, not `for (i of n)`.
+- Length: 3651 / 3718 / 4357 characters of `sketch.js`.
+
+## 1. Herbarium plate — Example code 1
+
+- URL: https://editor.p5js.org/kickingkeys/sketches/u3UerBiFY
+- Job: tea-stained specimen sheet, not a logo flower.
+- `noLoop()` at the **end of `draw()`**.
+- Paper: `background("#f4e8c1")`.
+- Grid: `2H` at weight 0.15, two `for` loops stepping 40px (this is the allowed grid loop).
+- Stains: `noStroke`, `fillBleed(0.4, "out")`, `fillTexture(0.85, 0.9)`, five unrolled `circle`s, opacity 25–30.
+- Ragged edges: `field("hand")`, four `rect(..., "center")` around the rim, then `noField()`.
+- Specimen: olive stem + sepals as `beginShape` polylines; three half-open bud petals (dusty rose / terracotta / overlapping centre); **three fallen petals** near the bottom. Each petal is its own fill/hatch/`beginShape` block.
+- Hatch: `hatchStyle("HB", "#2a2a2a", 0.4)` then `hatch(spacing, angle, { rand })` per mass.
+- Annotation: `noFill` + `noHatch`, `2H` leader lines with 2px circles, scale bar as five `line`s. No `random()`.
+- Brushes: `2H` / `HB` only.
+
+If the prompt is "field note", "pressed plant", "museum plate", start here.
+
+## 2. Ornamental tile — Hill feast
+
+- URL: https://editor.p5js.org/kickingkeys/sketches/2EkeaajQA
+- Job: 3×3 repeat, carpet / illumination, gold + teal + rose + crimson on `#fdf9f0`.
+- `noLoop()` in `setup()`.
+- Nine cells: nine `motifAt(startX + i * spacing, ...)` lines, comment `Grid Arrangement — 3×3, unrolled`.
+- Motif: circular teal halo wash → five `drawPetal(0..4)` (here 72° **is** the point) → gold `HB` stamen line → 5-circle stipple loop (`tiny + cheap`).
+- Petal: teardrop `beginShape(0.6)` in rose, crimson hatched inner shape, `pen` ink vein.
+- Border: unrolled TL/TR/BL/BR corner ticks in `2B` gold; border dots in a cheap `for`.
+- `push`/`pop`/`rotate` around each motif. `random()` only inside the stipple.
+
+If the prompt is "repeat", "brocade", "tile", "illumination", start here. Do not use this polar rosette on a naturalistic plate.
+
+## 3. Tropical glaze — Example 2
+
+- URL: https://editor.p5js.org/kickingkeys/sketches/pxoWEbk9C
+- Job: wet-on-wet night garden. `background("#051208")` in **setup**, then stacked glazes in `draw`.
+- Layer list, all unrolled:
+  1. four `bgGlaze` full-canvas `rect`s (opacity 180)
+  2. twenty `bloom()` water drops
+  3. ten `glow()` large low-opacity circles
+  4. fourteen `glazeFlower` in hot pink / orange / indigo under `field("curved")`
+  5. three `focalFlower` white-with-red-eye
+  6. `noField()`
+- Flower: five `petal(i)` calls (`i * 72 + random(-8, 8)`), red/dark eye `circle`, `flowLine` stamen, 6-dot pollen loop.
+- `endShape(CLOSE)` here; the other two sketches use `endShape(true)`.
+- Placement is `random(width/height)` — this recipe *wants* scatter. Herbarium does not.
+
+If the prompt is "night", "wet", "tropical", "glaze", "underpainting", start here.
+
+## What "worked after training" means
+
+March write-up: the 9-signal reward collapsed to identical 5-petal clip-art; pairwise-vs-pool made code shorter and images more like the love-tier pool. August samples are **still hibiscus-centric** because the pool was. The grammar transferred; the subject prior did not fully. When you draw a new subject, steal grammar, fight the hibiscus prior.

--- a/.opencode/skills/paint-with-code/references/transfer-example.md
+++ b/.opencode/skills/paint-with-code/references/transfer-example.md
@@ -1,0 +1,90 @@
+# Transfer example (oak leaf on a plate)
+
+Original teaching sketch. Same grammar as Example code 1, **different subject**. Use this as the pattern when the prompt is not a hibiscus: keep scaffold, allowlist, unroll, layering; change the masses.
+
+Not a sample from the trained policy. Do not ship this on Gyanateet's `/work`.
+
+```js
+async function setup() {
+  createCanvas(600, 600, WEBGL);
+  angleMode(DEGREES);
+  brush.scaleBrushes(3);
+  noLoop();
+}
+
+function draw() {
+  translate(-width / 2, -height / 2);
+  background("#f4e8c1");
+
+  brush.set("2H", "#7a7465", 0.15);
+  for (let x = 40; x <= 560; x += 40) brush.line(x, 40, x, 560);
+  for (let y = 40; y <= 560; y += 40) brush.line(40, y, 560, y);
+
+  brush.noStroke();
+  brush.fillBleed(0.4, "out");
+  brush.fillTexture(0.85, 0.9);
+  brush.fill("#9b7b5a", 30);
+  brush.circle(120, 140, 70, 0.2);
+  brush.circle(470, 430, 90, 0.3);
+  brush.circle(400, 100, 40, 0.15);
+
+  brush.fill("#4a3520", 40);
+  brush.fillBleed(0.5, "in");
+  brush.field("hand");
+  brush.rect(300, 8, 600, 16, "center");
+  brush.rect(300, 592, 600, 16, "center");
+  brush.rect(8, 300, 16, 600, "center");
+  brush.rect(592, 300, 16, 600, "center");
+  brush.noField();
+
+  brush.hatchStyle("HB", "#2a2a2a", 0.4);
+  brush.set("HB", "#333333", 0.4);
+
+  // Petiole — unrolled mass, not a leaf() loop
+  brush.fill("#6b705c", 50);
+  brush.fillBleed(0.2, "out");
+  brush.hatch(6, 45, { rand: 0.1 });
+  brush.beginShape(0.1);
+  brush.vertex(298, 430);
+  brush.vertex(304, 430);
+  brush.vertex(308, 520);
+  brush.vertex(294, 520);
+  brush.endShape(true);
+
+  // Blade (one lobe group)
+  brush.fill("#5c6b4a", 55);
+  brush.hatch(5, -20, { rand: 0.15 });
+  brush.beginShape(0.35);
+  brush.vertex(300, 420);
+  brush.vertex(210, 360);
+  brush.vertex(180, 250);
+  brush.vertex(240, 160);
+  brush.vertex(300, 200);
+  brush.vertex(360, 160);
+  brush.vertex(420, 250);
+  brush.vertex(390, 360);
+  brush.endShape(true);
+
+  // Fallen fragment
+  brush.fill("#7a5a3a", 40);
+  brush.hatch(4, 30, { rand: 0.2 });
+  brush.beginShape(0.5);
+  brush.vertex(150, 500);
+  brush.vertex(190, 470);
+  brush.vertex(230, 510);
+  brush.vertex(180, 540);
+  brush.endShape(true);
+
+  brush.noFill();
+  brush.noHatch();
+  brush.set("2H", "#2a2a2a", 0.35);
+  brush.line(240, 170, 90, 90);
+  brush.circle(90, 90, 2);
+  brush.line(90, 90, 55, 90);
+  brush.line(60, 540, 160, 540);
+  brush.line(60, 535, 60, 545);
+  brush.line(160, 535, 160, 545);
+}
+```
+
+Done when a reader can name the plant without the filename, and the sheet still reads as a plate (grid, stain, leader, bar) rather than a centred icon.

--- a/.opencode/skills/site-gates/SKILL.md
+++ b/.opencode/skills/site-gates/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: site-gates
+description: How to change anything on this portfolio without breaking it — branch rules, the full verification gate, fact-check exact-count discipline, and protected strings. Load before editing ANY file in src/ or content.
+---
+
+# Working on this repo safely
+
+## Branch and merge rules (MUST)
+
+1. Never commit to `main`. `main` is the live legacy GitHub Pages site;
+   the deployment workflow triggers on it.
+2. Work lands on the active `cursor/*-a347` branch. As of 2026-08-24 that
+   is `cursor/quiet-polish-a347` (stacked on `field-notes-a347`).
+3. Never push or open PRs unless the owner asks.
+
+## The gate (MUST run before and after every change session)
+
+```bash
+npm run lint && npm run notes && npm run voice && npm run facts && npm run smoke && npm run tokens && npm run build
+```
+
+- `facts`   — `fact-check.jsx`: exact occurrence counts + presence checks
+              per route, plus raw-hex scan of rendered markup.
+- `notes`   — `tools/check-notes.mjs`: note structure, spine kickers,
+              disclosure language, asset existence.
+- `voice`   — `tools/check-voice.mjs`: banned vocabulary + per-file
+              em-dash ceiling (4).
+- `tokens`  — regenerates `src/styles/m3-tokens.css` and enforces WCAG AA.
+- `smoke`   — SSRs every route; the 404 routes must contain the literal
+              phrase "isn't on the site".
+- `build`   — must produce `dist/404.html` (copied from index.html).
+
+## The one rule that outranks everything
+
+`fact-check.jsx` checks EXACT occurrence counts, not presence. If a
+rewrite drops a counted phrase from 2x to 1x, the build fails. NEVER fix
+a failing fact check by deleting the assertion or loosening the check.
+Fix the prose so the phrase survives the required number of times.
+
+### Protected-string classes
+
+- Counted figures: `['90.0%', 2]`, `['28.13 dB', 6]`, `['tbc', 3]` …
+- Counted prose: `'five you could check'`,
+  `'one you could check if you kept the original'`,
+  `'mental model, not a theorem'`, `'I have not trained LLaDA'` …
+- Presence words: `'schematic'`, `'framing, not measured'`,
+  `'self-distillation'`, band names on `/trust`.
+- The 404 phrase `"isn't on the site"` (straight apostrophe — the smoke
+  regex does not match the curly one).
+- `personas.js` statements: facts frozen; delivery may be softened only
+  with owner approval (granted 2026-08-24 for imperatives/redundant
+  "not still" clauses; every fact kept verbatim).
+
+## Voice rules (enforced additively)
+
+- Banned vocabulary lives in `tools/check-voice.mjs`; extend the list,
+  never loosen it.
+- Register: confident, not cocky. Dated declarative sentences. One
+  honest hedge per passage. No imperatives at the reader. No
+  self-superlatives. Defensive disclaimers ("a schematic, not a
+  measurement") are load-bearing evidence markers, not AI cadence.
+- `.opencode/skills/humanizer/SITE-OVERRIDE.md` governs any use of the
+  humanizer skill here: facts outrank the style list.
+
+## Commit style
+
+Sentence-case subject with a period, matching repo history. Body explains
+why, names what is locked/untouched. One concern per commit.

--- a/.opencode/skills/visual-system/SKILL.md
+++ b/.opencode/skills/visual-system/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: visual-system
+description: How the Material 3 Expressive token system, themes, dark mode, and the atmosphere layers work in this repo — and how to add or restyle a page without breaking gates. Load before touching src/styles/, any Theme usage, or page shells.
+---
+
+# The visual system
+
+## Tokens (generated — never hand-edit `m3-tokens.css`)
+
+- `npm run tokens` runs `tools/gen-m3-tokens.mjs`, which writes
+  `src/styles/m3-tokens.css` and enforces WCAG AA on 138 role pairs.
+- Themes: `study` (#c96442 terracotta), `ryukijano` (#6f9fd8 slate),
+  `ryoushi` (#b04a75 rose) — each generated in light AND dark
+  (`[data-theme='study']`, `[data-theme='study-dark']`, …).
+- To change a token: edit the generator, run `npm run tokens`. The file
+  header says so; a hand edit dies on the next regeneration.
+- `fact-check.jsx` fails on raw hex in rendered markup. Component CSS
+  (`m3.css`) must use `var()` / `color-mix()` / `currentColor` only.
+
+## Light/dark mode plumbing
+
+- `src/lib/mode.js` owns the storage key `site-mode` (localStorage) with
+  `prefers-color-scheme` fallback and live system-change propagation.
+- `index.html` has a pre-paint script stamping `html[data-mode]`; it MUST
+  agree with `mode.js` (same key, same fallback order).
+- `Theme` (in `src/components/m3/index.jsx`) resolves any palette name to
+  `${base}-${mode}`; pages declare palettes ("study"), never schemes.
+- Pre-mount ground colours for `html[data-mode]` are emitted by the
+  token generator.
+
+## Page shell recipe
+
+```jsx
+<Theme name="study" style={rootStyle}>   // rootStyle: position:'relative', minHeight:'100vh', background surface
+  <Atmosphere />                          // or variant="quiet" for reading pages
+  <SiteNav variant="ink" | "paper" (+ overlay on the folio) />
+  <main style={{ position: 'relative', zIndex: 1, ... }}>
+```
+
+- Atmosphere layers are decorative (`aria-hidden`, pointer-events:none).
+  Content must stack above via `position:relative; zIndex:1`.
+- Variants: `full` (wash + rings + grain) for index/persona/landing;
+  `quiet` (faint wash + grain, no rings) for notes and case studies;
+  home folio takes a bare `.atmo > .atmo__grain` only; Academic page
+  intentionally has none.
+- Rings drift via `@keyframes atmo-drift` (180s) wrapped in
+  `@media (prefers-reduced-motion: no-preference) and (min-width: 600px)`.
+  New motion goes inside the same media query; `src/base.css` also has a
+  global reduced-motion kill switch.
+
+## Type and layout
+
+- Type roles flow through `Text`/`typeStyle` → five CSS custom props per
+  role. Display/headline sizes are fluid (`clamp()` set in the generator);
+  body/label are fixed.
+- Fonts: Source Serif 4 (brand), IBM Plex Sans (plain), IBM Plex Mono
+  (figures/labels). No new families.
+- Component CSS lives in `src/styles/m3.css` under `@layer m3.components`;
+  its header rule: no literal colours, radii, or easings — vars only.
+
+## Identity elements (do not redesign casually)
+
+- Home is the Kanagawa plate (`KanagawaPlate.jsx` + `.folio__*` rules):
+  hung print, paper margin, kento marks (hikitsuke tick + kagi L) in the
+  gutter, daisen title-slip below. `box-sizing: content-box` on the kento
+  marks is load-bearing against the global border-box reset.
+- The `/trust` band colours are persona-invariant by design; never theme
+  them per persona.

--- a/NEXT.md
+++ b/NEXT.md
@@ -108,6 +108,13 @@ See `README.md`. Short list:
   shell recipe.
 - `browser-qa` — real-browser verification in this sandbox, servers,
   tunnels, and the browser-use API quirks.
+- `paint-with-code` — emit p5.brush the way the post-training Qwen
+  3.5 35B paint-with-code policy wrote it (WEBGL scaffold, closed
+  allowlist, unrolled motifs). Literature grammar, **not** Gyanateet's
+  run; do not put it on `/work`.
+- `creative-rl-design` — how that run actually trained: pairwise VLM
+  vs a hand-rated pool, binary compile/length gates, GEPA on a short
+  allowlist rather than a 400-line API dump.
 - `humanizer` (+ `SITE-OVERRIDE.md`), `design-taste-frontend`,
   `web-design-guidelines` — vendored external skills, scoped by their
   override notes.

--- a/NEXT.md
+++ b/NEXT.md
@@ -98,4 +98,18 @@ See `README.md`. Short list:
 8. One note, e.g. `src/content/blog/contrastive-ssl.js`
 9. `src/components/KanagawaPlate.jsx` + folio rules in `src/styles/m3.css`
 
+## Project skills (.opencode/skills/, loadable via the skill tool)
+
+- `site-gates` — branch rules, the full gate, exact-count discipline,
+  protected strings. Read before editing anything.
+- `content-authoring` — writing notes/case studies: structure,
+  disclosure language, asset conventions, fact registration.
+- `visual-system` — tokens, themes, dark mode, atmosphere layers, page
+  shell recipe.
+- `browser-qa` — real-browser verification in this sandbox, servers,
+  tunnels, and the browser-use API quirks.
+- `humanizer` (+ `SITE-OVERRIDE.md`), `design-taste-frontend`,
+  `web-design-guidelines` — vendored external skills, scoped by their
+  override notes.
+
 Run the full gate **before and after** every change.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two skills so a future agent can **draw** the way the trained paint-with-code policy wrote, and **design rewards** the way that run actually worked — without putting hibiscus on `/work` or claiming Gyanateet trained Qwen.

## What “worked after training” means

Surya Narreddi, Cameron Franz, and Alex Wang trained a language model (cached diagram: Qwen 3.5 35B) to emit **complete p5.brush JavaScript**, render it in Puppeteer, and update with GRPO.

The first nine-signal reward plateaued ~0.65: five quality/adherence judges correlated 0.85–0.95, a length ramp ate ~⅓ of the reward and died by step 30, HPSv3 (the term with variance) was weighted 0.10. Collapse: identical 5-petal clip-art.

The rubric that climbed: binary compile+uses-brush (0.05), binary length (0.05), HPSv3 (0.30), **pairwise VLM vs two hand-rated pool refs (0.60)**. Code compressed 13.5k → <2k tokens.

GEPA on the system prompt: a 400-line API dump hallucinated methods. The prompt that first produced 3/3 visible flowers was a **short allowlist, no docs, no examples**.

August 2026 editor samples (still hibiscus-heavy because the pool was) show the post-training grammar: WEBGL 600 + `brush.scaleBrushes(3)`, `draw()` with a centre-origin translate, unrolled motif/petal/glaze **calls**, `for` only for grids and cheap stipple, fill opacity 0–255, three jobs (tea-stained herbarium, 3×3 ornamental tile, dark tropical glazes).

Write-up: https://surya.website/rling-qwen-to-paint-with-code  
Samples: [Example code 1](https://editor.p5js.org/kickingkeys/sketches/u3UerBiFY), [Hill feast](https://editor.p5js.org/kickingkeys/sketches/2EkeaajQA), [Example 2](https://editor.p5js.org/kickingkeys/sketches/pxoWEbk9C)

## Skills in this PR

| Skill | Use when |
| --- | --- |
| `.opencode/skills/paint-with-code/` | Emitting a p5.brush sketch |
| `.opencode/skills/creative-rl-design/` | Designing an aesthetic reward, pool, or GEPA tool prompt |

The same trees are installed on this agent VM as a Cursor plugin at `~/.cursor/plugins/local/paint-with-code/`.

Also on this branch (previous commit): `site-gates`, `content-authoring`, `visual-system`, `browser-qa`, and a `NEXT.md` index.

## Honesty

Not Gyanateet’s training run. Not a `/work` case study. Not a Kanagawa replacement. The oak-leaf sketch in `transfer-example.md` is original teaching material, not a policy sample.

Stacked on `cursor/quiet-polish-a347`, not `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b25081f4-57e1-4ce7-b925-cb244a24a347?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b25081f4-57e1-4ce7-b925-cb244a24a347&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Add agent skills that capture the site's working conventions and the post-training paint-with-code and creative-reward design workflows.

New Features:
- Add loadable skills for generating p5.brush artwork using the observed post-training Qwen grammar and for designing creative RL rewards based on that training run.

Enhancements:
- Document reusable site authoring, visual-system, browser-QA, and repository-gating practices for future agents.
- Provide reference material covering the paint-with-code API allowlist, sketch patterns, training loop, and an original subject-transfer example.

Documentation:
- Index the available project skills and their intended use in NEXT.md.